### PR TITLE
fix: Use kafka consumer API for kafka state consumer instead of counting

### DIFF
--- a/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendConsumer.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendConsumer.java
@@ -48,6 +48,11 @@ public class KafkaBackendConsumer {
     consumerProperties.put(GROUP_ID_CONFIG, config.getKafkaBackendConsumerGroupId());
     consumer = new KafkaConsumer<>(consumerProperties);
 
+    List<PartitionInfo> partitions = consumer.partitionsFor(config.getJulieKafkaConfigTopic(), TIMEOUT);
+    if (partitions.size() > 1) {
+      LOGGER.warn("The configured state topic has more than one partition. This can potentially cause problems.");
+    }
+
     assignedTopicPartition = new TopicPartition(config.getJulieKafkaConfigTopic(), 0);
     var topicPartitions = Collections.singletonList(assignedTopicPartition);
     consumer.assign(topicPartitions);

--- a/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendConsumer.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendConsumer.java
@@ -1,30 +1,34 @@
 package com.purbon.kafka.topology.backend.kafka;
 
-import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
-
 import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.backend.BackendState;
 import com.purbon.kafka.topology.backend.KafkaBackend;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.serialization.Serdes;
 
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+
 public class KafkaBackendConsumer {
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
 
-  private Configuration config;
+  private final Configuration config;
   private KafkaConsumer<String, BackendState> consumer;
+  private TopicPartition assignedTopicPartition;
 
-  private AtomicBoolean running;
+  private final AtomicBoolean running;
 
   public KafkaBackendConsumer(Configuration config) {
     this.config = config;
@@ -41,24 +45,33 @@ public class KafkaBackendConsumer {
     consumerProperties.put(GROUP_ID_CONFIG, config.getKafkaBackendConsumerGroupId());
     consumer = new KafkaConsumer<>(consumerProperties);
 
-    var topicPartition = new TopicPartition(config.getJulieKafkaConfigTopic(), 0);
-    var topicPartitions = Collections.singletonList(topicPartition);
+    assignedTopicPartition = new TopicPartition(config.getJulieKafkaConfigTopic(), 0);
+    var topicPartitions = Collections.singletonList(assignedTopicPartition);
     consumer.assign(topicPartitions);
     consumer.seekToBeginning(topicPartitions);
   }
 
   public void retrieve(KafkaBackend callback) {
-    int times = 0;
     while (running.get()) {
-      ConsumerRecords<String, BackendState> records = consumer.poll(Duration.ofSeconds(10));
+      ConsumerRecords<String, BackendState> records = consumer.poll(TIMEOUT);
       callback.complete();
       for (ConsumerRecord<String, BackendState> record : records) {
         callback.apply(record);
       }
-      if (records.count() > 0 || times >= config.getKafkaBackendConsumerRetries()) {
+      if (isTopicRead()) {
         callback.initialLoadFinish();
       }
-      times += 1;
+    }
+  }
+
+  private boolean isTopicRead() {
+    try {
+      long position = consumer.position(assignedTopicPartition, TIMEOUT);
+      long endOffset = consumer.endOffsets(Collections.singletonList(assignedTopicPartition), TIMEOUT)
+              .get(assignedTopicPartition);
+      return position >= endOffset;
+    } catch (TimeoutException e) {
+      return false;
     }
   }
 

--- a/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendProducer.java
+++ b/src/main/java/com/purbon/kafka/topology/backend/kafka/KafkaBackendProducer.java
@@ -2,9 +2,6 @@ package com.purbon.kafka.topology.backend.kafka;
 
 import com.purbon.kafka.topology.Configuration;
 import com.purbon.kafka.topology.backend.BackendState;
-import java.util.Properties;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -13,12 +10,16 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
 public class KafkaBackendProducer {
 
   private static final Logger LOGGER = LogManager.getLogger(KafkaBackendProducer.class);
 
-  private String instanceId;
-  private Configuration config;
+  private final String instanceId;
+  private final Configuration config;
   private KafkaProducer<String, BackendState> producer;
   private Future<RecordMetadata> future;
 
@@ -39,7 +40,7 @@ public class KafkaBackendProducer {
   }
 
   public void save(BackendState backendState) {
-    var record = new ProducerRecord<>(config.getJulieKafkaConfigTopic(), instanceId, backendState);
+    var record = new ProducerRecord<>(config.getJulieKafkaConfigTopic(), 0, instanceId, backendState);
     future =
         producer.send(
             record,
@@ -52,7 +53,7 @@ public class KafkaBackendProducer {
     try {
       future.get();
     } catch (InterruptedException | ExecutionException e) {
-      e.printStackTrace();
+      LOGGER.error(e);
     }
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit messages are descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] An issue has been created for the pull requests. Some issues might require previous discussion.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This changes the previous behavior of the KafkaBackend which was using just a single poll to check the state into reading the topic until the consumer position matches the end offset. 


* **What is the current behavior?** (You can also link to an open issue here)
The consumer just reads until at least 1 record has been read or it has tried for a configured number of times.


* **What is the new behavior (if this is a feature change)?**
The consumer now reads until the consumer position matches the end offset. I also made sure the producer will always produce on partition 0 since that's the only one that the consumer is reading from. I also made sure the consumer outputs a warning if the state topic has more than 1 partition since that's not intended.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
